### PR TITLE
fix for  cran_packages("varhandle") errors

### DIFF
--- a/R/crandb-public-api.R
+++ b/R/crandb-public-api.R
@@ -226,7 +226,8 @@ rectangle_description <- function(description_list) {
 
 idesc_get_deps <- function(description_list) {
 
-  types <- intersect(names(description_list), dep_types())
+  types <- intersect(names(description_list)[lengths(description_list) > 0], 
+                     dep_types())
   res <- lapply(
     types,
     function(type) parse_deps(type, description_list[type])


### PR DESCRIPTION
Cf #72

It is due to a package with an empty Suggests field (as opposed to the expected _absence_ of the Suggests field when there's no such dependency)

I haven't added a test because I wasn't sure how, should I mock such a description for a test?

``` r

meta <- pkgsearch::cran_packages("varhandle")
meta$dependencies
#> [[1]]
#>      type  package  version
#> 1 Depends        R >= 3.0.1
#> 2 Imports    utils        *
#> 3 Imports graphics        *
pkgsearch::cran_package("varhandle")
#> CRAN package varhandle 2.0.4, 15 days ago
#> Title: Functions for Robust Variable Handling
#> Maintainer: Mehrad Mahmoudian <m.mahmoudian@gmail.com>
#> Author: Mehrad Mahmoudian [aut, cre]
#> BugReports:
#>     https://bitbucket.org/mehrad_mahmoudian/varhandle/issues
#> Date: 2019-10-21
#> Date/Publication: 2019-10-21 17:30:02 UTC
#> Depends: R (>= 3.0.1)
#> Description: Variables are the fundamental parts of each
#>     programming language but handling them efficiently might be
#>     frustrating for programmers. This package contains some
#>     functions to help user (especially data explorers) to make
#>     more sense of their variables and take the most out of
#>     variables and hardware resources. These functions are written,
#>     collected and crafted over 7 years of experience in
#>     statistical data analysis on high-dimensional data, and for
#>     each of them there was a need. Functions in this package are
#>     suppose to be efficient and easy to use, hence they will be
#>     frequently updated to make them more convenient.
#> Imports: utils (*), graphics (*)
#> License: GPL (>= 2)
#> MD5sum: 435dd8b0edb763d1deb5d379cd384195
#> NeedsCompilation: no
#> Packaged: 2019-10-21 17:12:21 UTC; mehrad
#> releases:
#> Repository: CRAN
#> Suggests: ()
#> URL: https://bitbucket.org/mehrad_mahmoudian/varhandle
meta <- pkgsearch::cran_packages("usethis")
meta$dependencies
#> [[1]]
#>        type    package  version
#> 1   Depends          R   >= 3.2
#> 2   Imports      clipr >= 0.3.0
#> 3   Imports clisymbols        *
#> 4   Imports     crayon        *
#> 5   Imports       curl   >= 2.7
#> 6   Imports       desc        *
#> 7   Imports         fs >= 1.3.0
#> 8   Imports         gh        *
#> 9   Imports      git2r  >= 0.23
#> 10  Imports       glue >= 1.3.0
#> 11  Imports      purrr        *
#> 12  Imports      rlang        *
#> 13  Imports  rprojroot   >= 1.2
#> 14  Imports rstudioapi        *
#> 15  Imports      stats        *
#> 16  Imports      utils        *
#> 17  Imports    whisker        *
#> 18  Imports      withr        *
#> 19  Imports       yaml        *
#> 20 Suggests       covr        *
#> 21 Suggests      knitr        *
#> 22 Suggests     magick        *
#> 23 Suggests    pkgdown >= 1.1.0
#> 24 Suggests  rmarkdown        *
#> 25 Suggests   roxygen2        *
#> 26 Suggests   spelling   >= 1.2
#> 27 Suggests     styler >= 1.0.2
#> 28 Suggests   testthat >= 2.1.0
```

<sup>Created on 2019-11-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>