### PR TITLE
is this a fix for the addin page title

### DIFF
--- a/R/addin.R
+++ b/R/addin.R
@@ -86,18 +86,16 @@ pkg_search_addin <- function(
   }
 
   ui <- shiny::navbarPage(
-    title = shiny::div(
-      shiny::div(
+    shiny::headerPanel(title = shiny::div(
         id = "rhub-logo",
         shiny::tags$a(
           shiny::img(src = "https://cdn.jsdelivr.net/gh/r-hub/branding@master/logo/rhub-square.svg",
-              width = "40px",
-              height = "40px"
+                     width = "40px",
+                     height = "40px"
           ),
           href = "https://docs.r-hub.io"
         )
-      )
-    ),
+    ), windowTitle = "Search CRAN packages with pkgsearch"),
     shiny::tabPanel("Search", searchQuery("search"), searchResults("search")),
     shiny::tabPanel("New packages", searchResults("new")),
     shiny::navbarMenu("Top packages",
@@ -540,7 +538,7 @@ addin_styles <- function() {
           #rhub-logo {
             right: 10px;
             top: 0px;
-            margin-top: -10px;
+            margin-top: -30px;
           }
           "
   )


### PR DESCRIPTION
It was easy... until I realized I had to tinker with CSS to make the R-hub logo appear high enough in the browser. Therefore, I'm not sure it's actually a fix. The CSS hack looks good in RStudio and Firefox for me, but doesn't seem very general.