### PR TITLE
Fix dependency handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # pkgsearch 3.0.2.9000
 
+* Fix dependency handling in the add-in (@salim-b, #101)
+
 # pkgsearch 3.0.2
 
 * The RStudio addin now gives a better error more missing dependencies

--- a/R/addin.R
+++ b/R/addin.R
@@ -29,6 +29,8 @@ pkg_search_addin <- function(
   query = "",
   viewer = c("dialog", "browser")) {
 
+  needs_packages(c("memoise", "shiny", "shinyjs", "shinyWidgets", "whoami"))
+
   query
   maint <- whoami::email_address(fallback = "")
 
@@ -47,8 +49,6 @@ pkg_search_addin <- function(
     `cnt-maint-prev` = 0L,
     `cnt-maint-next` = 0L
   )
-
-  needs_packages(c("memoise", "shiny", "shinyjs", "shinyWidgets", "whoami"))
 
   if (is.character(viewer)) {
     mode <- match.arg(viewer)


### PR DESCRIPTION
Package `whoami` was used before it was checked if it is actually available (`needs_packages()`).